### PR TITLE
add fields ignore_email ignore_sms in model data all imports

### DIFF
--- a/reference/v1/bank_billets.markdown
+++ b/reference/v1/bank_billets.markdown
@@ -52,6 +52,7 @@ layout: pt
 | **customer_ignore_sms**         | Não | Boolean | | Nunca enviar SMS para este cliente
 | **customer_contact_person**     | Não   | String  | 120     | Contato do Pagador
 | **ignore_email**                | Não | Boolean | | Não enviar este boleto por email
+| **ignore_sms**                  | Não | Boolean | | Não enviar este boleto por SMS
 | **meta**                        | Não   | Json | | Disponível para envio de um JSON. Pode ser usado para salvar dados que não existam dentro do Boleto Simples. Exemplo: {"pedido": 12345}
 | **status**                      | N/A   | String  |         | Situação do boleto ([possíveis valores](#status))
 | **paid_at**                     | N/A   | Date    |         | Data do pagamento

--- a/reference/v1/customers.markdown
+++ b/reference/v1/customers.markdown
@@ -45,7 +45,8 @@ layout: pt
 | **truncated_address**  | Não         | String  | 40      | Endereço para remessa                                   |
 | **external_code**      | Não         | String  | 60      | Código externo do Cliente                               |
 | **tags**               | Não         | Array   |         | Etiquetas (Tags)                                        |
-| **ignore_email**       | Não         | Boolean |         | Nunca enviar e-mail para este cliente                   |
+| **ignore_email**       | Não         | Boolean |         | Nunca enviar e-mail para este cliente
+| **ignore_sms**         | Não         | Boolean |         | Nunca enviar SMS para este cliente                  |
 
 ### Criar cliente
 

--- a/reference/v1/imports/bank_billets.markdown
+++ b/reference/v1/imports/bank_billets.markdown
@@ -31,6 +31,10 @@ layout: pt
 | **source_file_size**   | N/A   | Integer  |         | Tamanho em bytes do arquivo
 | **status**             | N/A   | String  |         | Situação do arquivo ([possíveis valores](#status))
 | **created_via_api**    | N/A   | Boolean |         | Enviado pela API
+| **customer_ignore_email**| Não | Boolean |         | Nunca enviar e-mail para este cliente
+| **customer_ignore_sms**  | Não | Boolean |         | Nunca enviar SMS para este cliente
+| **ignore_email**         | Não | Boolean |         | Não enviar este boleto por email
+| **ignore_sms**           | Não | Boolean |         | Não enviar este boleto por SMS
 
 ### Dicionário de Dados
 

--- a/reference/v1/imports/customer_subscriptions.markdown
+++ b/reference/v1/imports/customer_subscriptions.markdown
@@ -32,6 +32,8 @@ layout: pt
 | **source_file_size**   | N/A   | Integer  |         | Tamanho em bytes do arquivo
 | **status**             | N/A   | String  |         | Situação do arquivo ([possíveis valores](#status))
 | **created_via_api**    | N/A   | Boolean |         | Enviado pela API
+| **customer_ignore_email**| Não | Boolean |         | Nunca enviar e-mail para este cliente 
+| **customer_ignore_sms**  | Não | Boolean |         | Nunca enviar SMS para este cliente  
 
 ### Dicionário de Dados
 

--- a/reference/v1/imports/customers.markdown
+++ b/reference/v1/imports/customers.markdown
@@ -32,6 +32,8 @@ layout: pt
 | **source_file_size**   | N/A   | Integer  |         | Tamanho em bytes do arquivo
 | **status**             | N/A   | String  |         | Situação do arquivo ([possíveis valores](#status))
 | **created_via_api**    | N/A   | Boolean |         | Enviado pela API
+| **ignore_email**       | Não         | Boolean |         | Nunca enviar e-mail para este cliente
+| **ignore_sms**         | Não         | Boolean |         | Nunca enviar SMS para este cliente
 
 ### Dicionário de Dados
 

--- a/reference/v1/imports/installments.markdown
+++ b/reference/v1/imports/installments.markdown
@@ -32,6 +32,8 @@ layout: pt
 | **source_file_size**   | N/A   | Integer  |         | Tamanho em bytes do arquivo
 | **status**             | N/A   | String  |         | Situação do arquivo ([possíveis valores](#status))
 | **created_via_api**    | N/A   | Boolean |         | Enviado pela API
+| **customer_ignore_email** | Não| Boolean |         | Nunca enviar e-mail para este cliente
+| **customer_ignore_sms** | Não  | Boolean |         | Nunca enviar SMS para este cliente
 
 ### Dicionário de Dados
 


### PR DESCRIPTION
Adicionar os campos que ignoram o envio de email e SMS nos modelo de dados dos imports na documentação da API.

Card do trello: https://trello.com/c/wqolFpiT/2083-incluir-na-documenta%C3%A7%C3%A3o-da-api-dados-de-n%C3%A3o-enviar-e-mailignoreemail-e-smsignoresms-na-importa%C3%A7%C3%A3o-via-csv